### PR TITLE
Android development dependency injection and network

### DIFF
--- a/android/app/src/main/java/com/koleff/kare_android/common/Constants.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/common/Constants.kt
@@ -1,0 +1,16 @@
+package com.koleff.kare_android.common
+
+object Constants {
+    const val SCHEME_LOCAL = "http"
+    const val SCHEME = "https"
+    const val PORT = 8080
+
+    const val BASE_URL = "" //TODO: add deployed server url
+    const val BASE_URL_FULL = "$SCHEME://$BASE_URL/"
+
+    const val BASE_LOCAL_URL = "localhost"
+    const val BASE_LOCAL_URL_FULL = "$SCHEME_LOCAL://$BASE_LOCAL_URL"
+    const val BASE_LOCAL_URL_FULL_PORT = "$SCHEME_LOCAL://$BASE_LOCAL_URL:$PORT/"
+
+    const val useFakeApi = false
+}

--- a/android/app/src/main/java/com/koleff/kare_android/common/Network.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/common/Network.kt
@@ -1,0 +1,61 @@
+package com.koleff.kare_android.common
+
+import com.koleff.kare_android.data.model.response.base_response.ServerResponseData
+import com.koleff.kare_android.data.model.wrapper.ResultWrapper
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+object Network {
+    private const val MAX_RETRY_COUNT = 1
+
+    suspend fun <T> executeApiCall(
+        dispatcher: CoroutineDispatcher,
+        apiCall: suspend () -> T,
+        unsuccessfulRetriesCount: Int = 0
+    ): Flow<ResultWrapper<T>> where T : ServerResponseData = flow {
+        try {
+            emit(ResultWrapper.Loading())
+
+            val apiResult = apiCall.invoke()
+
+            if (apiResult.isSuccessful) {
+                emit(ResultWrapper.Success(apiResult))
+            } else {
+                emit(
+                    ResultWrapper.ApiError(
+                        apiResult.error,
+                        apiResult
+                    )
+                )
+            }
+        } catch (throwable: Throwable) {
+            throwable.printStackTrace()
+            doRetryCall(
+                dispatcher,
+                apiCall,
+                null,
+                unsuccessfulRetriesCount
+            )
+        }
+    }.flowOn(dispatcher)
+
+    private suspend fun <T> doRetryCall(
+        dispatcher: CoroutineDispatcher,
+        apiCall: suspend () -> T,
+        apiResult: T?,
+        unsuccessfulRetriesCount: Int = 0
+    ): Flow<ResultWrapper<T>> where T : ServerResponseData = flow {
+        if (unsuccessfulRetriesCount < MAX_RETRY_COUNT) {
+            executeApiCall(dispatcher, apiCall, unsuccessfulRetriesCount + 1)
+        } else {
+            emit(
+                ResultWrapper.ApiError(
+                    apiResult?.error,
+                    apiResult
+                )
+            )
+        }
+    }
+}

--- a/android/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/common/di/AppModule.kt
@@ -1,0 +1,75 @@
+package com.koleff.kare_android.common.di
+
+import androidx.multidex.BuildConfig
+import com.jakewharton.retrofit2.adapter.kotlin.coroutines.CoroutineCallAdapterFactory
+import com.koleff.kare_android.common.Constants
+import com.koleff.kare_android.data.remote.ExerciseApi
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.logging.HttpLoggingInterceptor
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.converter.moshi.MoshiConverterFactory
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideOkHttpClient(): OkHttpClient {
+        val okHttpClientBuilder = OkHttpClient.Builder()
+            .addInterceptor(Interceptor { chain ->
+                val original = chain.request()
+
+                val newUrl = original.url.newBuilder()
+                    .scheme(Constants.SCHEME)
+                    .host(Constants.BASE_URL_FULL)
+//                    .port(Constants.PORT) //if port is needed
+//                    .addQueryParameter("access_key", Constants.API_KEY) //if API key is needed
+                    .build()
+
+                val request = original.newBuilder()
+                    .method(original.method, original.body)
+                    .url(newUrl)
+                    .build()
+
+                chain.proceed(request)
+            })
+
+        //Logging
+        val logging = HttpLoggingInterceptor()
+        logging.setLevel(HttpLoggingInterceptor.Level.BODY)
+        if (BuildConfig.DEBUG) okHttpClientBuilder.addInterceptor(logging)
+
+        return okHttpClientBuilder.build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideMoshi(): Moshi {
+        return Moshi.Builder()
+            .add(KotlinJsonAdapterFactory())
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideExerciseApi(okHttpClient: OkHttpClient, moshi: Moshi): ExerciseApi {
+        return Retrofit.Builder()
+            .baseUrl(Constants.BASE_URL_FULL)
+            .client(okHttpClient)
+            .addCallAdapterFactory(CoroutineCallAdapterFactory())
+            .addConverterFactory(MoshiConverterFactory.create(moshi)) //TODO: test with backend to decide which converter...
+//            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+            .create(ExerciseApi::class.java)
+    }
+}

--- a/android/app/src/main/java/com/koleff/kare_android/data/model/request/GetExercisesRequest.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/model/request/GetExercisesRequest.kt
@@ -1,0 +1,4 @@
+package com.koleff.kare_android.data.model.request
+
+class GetExercisesRequest {
+}

--- a/android/app/src/main/java/com/koleff/kare_android/data/model/response/GetExercisesResponse.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/model/response/GetExercisesResponse.kt
@@ -1,0 +1,4 @@
+package com.koleff.kare_android.data.model.response
+
+class GetExercisesResponse {
+}

--- a/android/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/BaseResponse.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/BaseResponse.kt
@@ -1,0 +1,10 @@
+package com.koleff.kare_android.data.model.response.base_response
+
+import com.squareup.moshi.Json
+
+open class BaseResponse(
+    @Json(name = "success")
+    val isSuccessful: Boolean = true,
+    @field:Json(name = "error")
+    val error: KareError?
+)

--- a/android/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/KareError.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/KareError.kt
@@ -1,0 +1,20 @@
+package com.koleff.kare_android.data.model.response.base_response
+
+import com.koleff.kare_android.R
+
+enum class KareError(
+    val errorCode: String,
+    val errorMessageResourceId: Int,
+    var errorType: ErrorType) {
+
+    OK("success", R.string.text_success, ErrorType.SUCCESS),
+    GENERIC("error_generic", R.string.text_internal_exception, ErrorType.INTERNAL);
+
+    companion object {
+        fun fromErrorCode(errorCode: String?): KareError = values().find { it.errorCode == errorCode } ?: GENERIC
+    }
+}
+
+enum class ErrorType {
+    SERVER, INTERNAL, LOGIN, SUCCESS, ACCESS_DENIED
+}

--- a/android/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/ServerResponseData.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/model/response/base_response/ServerResponseData.kt
@@ -1,0 +1,11 @@
+package com.koleff.kare_android.data.model.response.base_response
+
+open class ServerResponseData(
+    var isSuccessful: Boolean,
+    val error: KareError = KareError.GENERIC,
+) {
+    constructor(response: BaseResponse?) : this(
+        isSuccessful = response?.isSuccessful ?: false || response?.error == KareError.GENERIC,
+        error = KareError.fromErrorCode(response?.error?.errorCode)
+    )
+}

--- a/android/app/src/main/java/com/koleff/kare_android/data/model/wrapper/ResultWrapper.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/model/wrapper/ResultWrapper.kt
@@ -1,0 +1,12 @@
+package com.koleff.kare_android.data.model.wrapper
+
+import com.koleff.kare_android.data.model.response.base_response.KareError
+
+sealed class ResultWrapper<out T>{
+    class Success<out T>(val data: T) : ResultWrapper<T>()
+    class ApiError<out T>(
+        val error: KareError? = null,
+        val value: T? = null
+    ) : ResultWrapper<T>()
+    class Loading<T> : ResultWrapper<T>()
+}

--- a/android/app/src/main/java/com/koleff/kare_android/data/remote/ExerciseApi.kt
+++ b/android/app/src/main/java/com/koleff/kare_android/data/remote/ExerciseApi.kt
@@ -1,0 +1,18 @@
+package com.koleff.kare_android.data.remote
+
+import com.koleff.kare_android.data.model.request.GetExercisesRequest
+import com.koleff.kare_android.data.model.response.GetExercisesResponse
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface ExerciseApi {
+
+    @GET("api/v1/exercise/get/{muscle_group}/all") //TODO: update endpoint...
+    suspend fun getExercises(
+        @Path("muscle_group") muscleGroup: String,
+        @Body body: GetExercisesRequest
+    ): GetExercisesResponse
+
+
+}

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
     <string name="app_name">My Application</string>
+    <string name="text_success">Success</string>
+    <string name="text_internal_exception">Internal exception</string>
 </resources>


### PR DESCRIPTION
In this branch l have:
- Added connection with backend server via Retrofit.
- Added Constants class to hold data such as server url, port, etc.
- Added BaseResponse class which every response from server will extend.
- Added ResultWrapper for all result types from server (Loading, Error and Success).
- Added ServerResponseData -> wrapper for any kind of data from the server (Error / Success)
- Added AppModule for dependency injection via Dagger Hilt
- Added demo API, response and request
- Added string resources